### PR TITLE
Add function to parse cron expression

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,9 @@
+package cmd
+
+var (
+  locale = "en"
+  version = false
+  dayOfWeek = false
+  verbose = false
+  format24 = false
+)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+  "fmt"
+
+  "github.com/lnquy/cron"
+)
+
+func GetParsedExpressionDisplay(args []string) string {
+  expr := args[0]
+
+  loc, err := parseLocale()
+  if err != nil {
+    return fmt.Sprintln(err.Error())
+  }
+
+  exprDesc, err := getExprDescriptor(loc)
+  if err != nil {
+    return fmt.Sprintln(err.Error())
+  }
+
+  desc, err := exprDesc.ToDescription(args[0], loc)
+  if err != nil {
+    return fmt.Sprintln(err.Error())
+  }
+
+  return fmt.Sprintf("%s: %s\n", expr, desc)
+}
+
+func getExprDescriptor(loc cron.LocaleType) (exprDesc *cron.ExpressionDescriptor, err error) {
+  exprDesc, err = cron.NewDescriptor(
+      cron.Use24HourTimeFormat(format24),
+      cron.DayOfWeekStartsAtOne(dayOfWeek),
+      cron.Verbose(verbose),
+      cron.SetLocales(loc),
+  )
+
+  if err != nil {
+    return nil, fmt.Errorf("ctap: failed to initialize cron expression descriptor: %s", err)
+  }
+
+  return exprDesc, nil
+}
+
+func parseLocale() (loc cron.LocaleType, err error) {
+  loc, err = cron.ParseLocale(locale)
+  if err != nil {
+    return loc, fmt.Errorf("ctap: failed to get locale: %w", err)
+  }
+
+  return loc, nil
+}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -29,10 +29,10 @@ func GetParsedExpressionDisplay(args []string) string {
 
 func getExprDescriptor(loc cron.LocaleType) (exprDesc *cron.ExpressionDescriptor, err error) {
   exprDesc, err = cron.NewDescriptor(
-      cron.Use24HourTimeFormat(format24),
-      cron.DayOfWeekStartsAtOne(dayOfWeek),
-      cron.Verbose(verbose),
-      cron.SetLocales(loc),
+    cron.Use24HourTimeFormat(format24),
+    cron.DayOfWeekStartsAtOne(dayOfWeek),
+    cron.Verbose(verbose),
+    cron.SetLocales(loc),
   )
 
   if err != nil {

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  "github.com/Sean0628/ctap/test"
+)
+
+const cronExpression = "0 15 * * 1-5"
+
+func TestGetParsedExpressionDisplay(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintln(cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Monday through Friday"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplayInSpecifiedLocale(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintf("-l@ja@%s", cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: 次において実施03:00 PM、月曜日 から 金曜日 まで"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplayInSpecifiedLocaleLong(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintf("--locale@ja@%s", cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: 次において実施03:00 PM、月曜日 から 金曜日 まで"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplayIn24TimeFormat(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintf("--24-hour@%s", cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: At 15:00, Monday through Friday"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplayStartingAt1(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintf("-d@%s", cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Monday through Friday"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplayStartingAt1Long(t *testing.T) {
+  result := test.RunCmd(rootCmd, fmt.Sprintf("--dow-starts-at-one@%s", cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Sunday through Thursday"
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -6,60 +6,72 @@ import (
   "testing"
 
   "github.com/Sean0628/ctap/test"
+  "github.com/spf13/cobra"
 )
 
-const cronExpression = "0 15 * * 1-5"
+const cronExpression = "0 05 * * 1-5"
+
+
+func getRootCommand() *cobra.Command {
+  return New()
+}
 
 func TestGetParsedExpressionDisplay(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintln(cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprint(cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Monday through Friday"
+  expectedOutput := "0 05 * * 1-5: At 05:00 AM, Monday through Friday"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
 func TestGetParsedExpressionDisplayInSpecifiedLocale(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintf("-l@ja@%s", cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-l@ja@%s", cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: 次において実施03:00 PM、月曜日 から 金曜日 まで"
+  expectedOutput := "0 05 * * 1-5: 次において実施05:00 AM、月曜日 から 金曜日 まで"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
 func TestGetParsedExpressionDisplayInSpecifiedLocaleLong(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintf("--locale@ja@%s", cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("--locale@ja@%s", cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: 次において実施03:00 PM、月曜日 から 金曜日 まで"
+  expectedOutput := "0 05 * * 1-5: 次において実施05:00 AM、月曜日 から 金曜日 まで"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
 func TestGetParsedExpressionDisplayIn24TimeFormat(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintf("--24-hour@%s", cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("--24-hour@%s", cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: At 15:00, Monday through Friday"
+  expectedOutput := "0 05 * * 1-5: At 05:00, Monday through Friday"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
 func TestGetParsedExpressionDisplayStartingAt1(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintf("-d@%s", cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-d@%s", cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Monday through Friday"
+  expectedOutput := "0 05 * * 1-5: At 05:00 AM, Sunday through Thursday"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
 func TestGetParsedExpressionDisplayStartingAt1Long(t *testing.T) {
-  result := test.RunCmd(rootCmd, fmt.Sprintf("--dow-starts-at-one@%s", cronExpression))
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("--dow-starts-at-one@%s", cronExpression))
   if result.Error != nil {
     t.Error(result.Error)
   }
-  expectedOutput := "0 15 * * 1-5: At 03:00 PM, Sunday through Thursday"
+  expectedOutput := "0 05 * * 1-5: At 05:00 AM, Sunday through Thursday"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,12 +8,6 @@ import (
 )
 
 var (
-  locale string
-  version bool
-  dayOfWeek bool
-  verbose bool
-  format24 bool
-
   rootCmd = &cobra.Command{
     Use:   "ctap",
     Short: "CLI crontab parser",
@@ -28,7 +22,6 @@ var (
         return nil
       }
 
-      cmd.Print(GetParsedExpressionDisplay(args))
       return nil
     },
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,11 @@ import (
 )
 
 var (
+  locale string
   version bool
+  dayOfWeek bool
+  verbose bool
+  format24 bool
 
   rootCmd = &cobra.Command{
     Use:   "ctap",
@@ -19,8 +23,12 @@ var (
 				cmd.Print(GetVersionDisplay())
 				return nil
 			}
-      cmd.Println(cmd.UsageString())
+      if len(args) < 1 {
+        cmd.Println(cmd.UsageString())
+        return nil
+      }
 
+      cmd.Print(GetParsedExpressionDisplay(args))
       return nil
     },
 }
@@ -34,5 +42,9 @@ func Execute() {
 }
 
 func init() {
-  rootCmd.Flags().BoolVarP(&version, "version", "v", false, "Prints version information")
+	rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
+  rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information")
+	rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
+	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")
+	rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,15 +13,15 @@ var (
     Short: "CLI crontab parser",
     Long: `ctap is a CLI crontab parser written in Go.`,
     RunE: func(cmd *cobra.Command, args []string) error {
-			if version {
-				cmd.Print(GetVersionDisplay())
-				return nil
-			}
+      if version {
+        cmd.Print(GetVersionDisplay())
+        return nil
+      }
       if len(args) < 1 {
         cmd.Println(cmd.UsageString())
         return nil
       }
-
+      cmd.Print(GetParsedExpressionDisplay(args))
       return nil
     },
 }
@@ -35,9 +35,9 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
+  rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
   rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information")
-	rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")
-	rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format")
+  rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
+  rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")
+  rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-  "os"
-  "fmt"
-
   "github.com/spf13/cobra"
 )
 
-var (
-  rootCmd = &cobra.Command{
+func New() *cobra.Command {
+  var rootCmd = &cobra.Command {
     Use:   "ctap",
     Short: "CLI crontab parser",
     Long: `ctap is a CLI crontab parser written in Go.`,
@@ -24,20 +21,13 @@ var (
       cmd.Print(GetParsedExpressionDisplay(args))
       return nil
     },
-}
-
-)
-func Execute() {
-  if err := rootCmd.Execute(); err != nil {
-    fmt.Fprintln(os.Stderr, err)
-    os.Exit(1)
   }
-}
 
-func init() {
   rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
   rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information")
   rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
   rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")
   rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format")
+
+  return rootCmd
 }

--- a/ctap.go
+++ b/ctap.go
@@ -1,9 +1,16 @@
 package main
 
 import (
-	"github.com/Sean0628/ctap/cmd"
+  "os"
+  "fmt"
+
+  command "github.com/Sean0628/ctap/cmd"
 )
 
 func main() {
-  cmd.Execute()
+  cmd := command.New()
+  if err := cmd.Execute(); err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    os.Exit(1)
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Sean0628/ctap
 go 1.14
 
 require (
+	github.com/lnquy/cron v1.0.1
 	github.com/spf13/cobra v1.1.1
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 )

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lnquy/cron v1.0.1 h1:yYcu8TBex8/Ew7FTtugYe4+canCL6HX0HhK6tq+nGM4=
+github.com/lnquy/cron v1.0.1/go.mod h1:hu2Y7H68/8oKk6T4+K4qdbopbnaP4rGltK3ylWiiDss=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-test-all:
+test:
   go test ./...
 lint:
   golangci-lint run

--- a/justfile
+++ b/justfile
@@ -1,2 +1,4 @@
 test-all:
   go test ./...
+lint:
+  golangci-lint run

--- a/test/utils.go
+++ b/test/utils.go
@@ -29,4 +29,3 @@ func AssertResult(t *testing.T, expectedValue interface{}, actualValue interface
     t.Error("Expected <", expectedValue, "> but got <", actualValue, ">", fmt.Sprintf("%T", actualValue))
   }
 }
-

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+  "bytes"
+  "fmt"
+  "strings"
+  "testing"
+  "github.com/spf13/cobra"
+)
+
+type resulter struct {
+  Error error
+  Output string
+  Command *cobra.Command
+}
+
+func RunCmd(c *cobra.Command, input string) resulter {
+  buf := new(bytes.Buffer)
+  c.SetOutput(buf)
+  c.SetArgs(strings.Split(input, "@"))
+  err := c.Execute()
+  output := buf.String()
+  return resulter{err, output, c}
+}
+
+func AssertResult(t *testing.T, expectedValue interface{}, actualValue interface{}) {
+  t.Helper()
+  if expectedValue != actualValue {
+    t.Error("Expected <", expectedValue, "> but got <", actualValue, ">", fmt.Sprintf("%T", actualValue))
+  }
+}
+

--- a/test/utils.go
+++ b/test/utils.go
@@ -26,6 +26,6 @@ func RunCmd(c *cobra.Command, input string) resulter {
 func AssertResult(t *testing.T, expectedValue interface{}, actualValue interface{}) {
   t.Helper()
   if expectedValue != actualValue {
-    t.Error("Expected <", expectedValue, "> but got <", actualValue, ">", fmt.Sprintf("%T", actualValue))
+    t.Error("\nExpected: ", expectedValue, "\n     Got: ", actualValue, fmt.Sprintf("\n    Type:  %T", actualValue))
   }
 }


### PR DESCRIPTION
## Summary
- add function to parse cron expression, and related options.
- add test for the function.
- add shortcut command for lint.