### PR TITLE
Add function to parse cron expression from input file(w/ -i, --input option)

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,7 +1,19 @@
 package cmd
 
+import (
+  "regexp"
+)
+
+const (
+  validCronExpressionCount = 5
+  commentOutPrefix = "#"
+)
+
 var (
+  validCronExpression = regexp.MustCompile(`^[wWlL /?,*#\-0-9]*$`)
+
   locale = "en"
+  file = ""
   version = false
   dayOfWeek = false
   verbose = false

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -2,19 +2,17 @@ package cmd
 
 import (
   "fmt"
-
-  "github.com/lnquy/cron"
 )
 
 func GetParsedExpressionDisplay(args []string) string {
   expr := args[0]
 
-  loc, err := parseLocale()
+  loc, err := GetParseLocale()
   if err != nil {
     return fmt.Sprintln(err.Error())
   }
 
-  exprDesc, err := getExprDescriptor(loc)
+  exprDesc, err := GetExprDescriptor(loc)
   if err != nil {
     return fmt.Sprintln(err.Error())
   }
@@ -25,28 +23,4 @@ func GetParsedExpressionDisplay(args []string) string {
   }
 
   return fmt.Sprintf("%s: %s\n", expr, desc)
-}
-
-func getExprDescriptor(loc cron.LocaleType) (exprDesc *cron.ExpressionDescriptor, err error) {
-  exprDesc, err = cron.NewDescriptor(
-    cron.Use24HourTimeFormat(format24),
-    cron.DayOfWeekStartsAtOne(dayOfWeek),
-    cron.Verbose(verbose),
-    cron.SetLocales(loc),
-  )
-
-  if err != nil {
-    return nil, fmt.Errorf("ctap: failed to initialize cron expression descriptor: %s", err)
-  }
-
-  return exprDesc, nil
-}
-
-func parseLocale() (loc cron.LocaleType, err error) {
-  loc, err = cron.ParseLocale(locale)
-  if err != nil {
-    return loc, fmt.Errorf("ctap: failed to get locale: %w", err)
-  }
-
-  return loc, nil
 }

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -19,6 +19,10 @@ func GetParsedExpressionFromFileDisplay(args []string) string {
   }
 
   exprDesc, err := GetExprDescriptor(loc)
+  if err != nil {
+    return fmt.Sprintln(err.Error())
+  }
+
   if len(filePath) > 0 {
     f, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
     if err != nil {
@@ -64,7 +68,7 @@ func stream(exprDesc *cron.ExpressionDescriptor, localeType cron.LocaleType, rea
 
 
 func normalize(line string) (expr string, remainder string) {
-  if strings.HasPrefix(line, "#") {
+  if strings.HasPrefix(line, commentOutPrefix) {
     return "", line
   }
 

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+  "bufio"
+  "fmt"
+  "io"
+  "os"
+  "strings"
+
+  "github.com/lnquy/cron"
+)
+
+func GetParsedExpressionFromFileDisplay(args []string) string {
+  filePath := strings.TrimSpace(file)
+
+  loc, err := GetParseLocale()
+  if err != nil {
+    return fmt.Sprintln(err.Error())
+  }
+
+  exprDesc, err := GetExprDescriptor(loc)
+  if len(filePath) > 0 {
+    f, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
+    if err != nil {
+      fmt.Printf("failed to open file: %s", err)
+    }
+
+    if err := stream(exprDesc, loc, bufio.NewReader(f)); err != nil {
+      fmt.Printf("error: %s", err)
+    }
+
+    return ""
+  }
+
+  return ""
+}
+
+func stream(exprDesc *cron.ExpressionDescriptor, localeType cron.LocaleType, reader *bufio.Reader) error {
+  for {
+    line, _, err := reader.ReadLine()
+    if err != nil && err == io.EOF {
+      return nil
+    }
+
+    expr, remaining := normalize(string(line))
+
+    if len(expr) == 0 {
+      continue
+    }
+
+    desc, err := exprDesc.ToDescription(expr, localeType)
+    if err != nil {
+      fmt.Printf("error: %s\n", err)
+      continue
+    }
+
+    if len(remaining) > 0 {
+      fmt.Printf("%s: %s | %s\n", expr, desc, remaining)
+      continue
+    }
+    fmt.Printf("%s: %s\n", expr, desc)
+  }
+}
+
+
+func normalize(line string) (expr string, remainder string) {
+  if strings.HasPrefix(line, "#") {
+    return "", line
+  }
+
+  parts := strings.Fields(line)
+  if len(parts) < validCronExpressionCount {
+    return "", line
+  }
+
+  if !validCronExpression.MatchString(line) {
+    return strings.Join(parts[:validCronExpressionCount], " "), strings.Join(parts[validCronExpressionCount:], " ")
+  }
+
+  return line, ""
+}

--- a/cmd/parse_file_test.go
+++ b/cmd/parse_file_test.go
@@ -85,7 +85,6 @@ func TestGetParsedExpressionFromFileDisplay_emptyFile(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-// TODO
 func TestGetParsedExpressionFromFileDisplay_Locale(t *testing.T) {
   fileName := test.WriteTmpCrontabFile(crontabContent)
   defer test.RemoveTmpCrontabFile(fileName)

--- a/cmd/parse_file_test.go
+++ b/cmd/parse_file_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  "github.com/Sean0628/ctap/test"
+)
+
+const crontabContent = `# run the drupal cron process every hour of every day
+0 * * * * /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+
+# reset the contact form just after midnight
+5 0 * * * /var/www/devdaily.com/bin/resetContactForm.sh
+
+# db backup script
+0 05 * * 1-5 root /var/www/db-backup.sh `
+
+func TestGetParsedExpressionFromFileDisplay_Input(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("-i@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00 AM, Monday through Friday | root /var/www/db-backup.sh`
+
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_InputLong(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("--input@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00 AM, Monday through Friday | root /var/www/db-backup.sh`
+
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_noExistingFile(t *testing.T) {
+  fileName := "dummy.txt"
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("--input@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := fmt.Sprintf("ctap: failed to open %s: no such file or directory.", fileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_emptyFile(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile("")
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("--input@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := "ctap: noting to be printed out. possibly input file does not have any contents."
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+// TODO
+func TestGetParsedExpressionFromFileDisplay_Locale(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-i@%s@-l@ja", fileName))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := `0 * * * *: 毎時 | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: 次において実施12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: 次において実施05:00 AM、月曜日 から 金曜日 まで | root /var/www/db-backup.sh`
+
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_24hrsFormat(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-i@%s@--24-hour", fileName))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 00:05 | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00, Monday through Friday | root /var/www/db-backup.sh`
+
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_DowStartsAtOne(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-i@%s@-d", fileName))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00 AM, Sunday through Thursday | root /var/www/db-backup.sh`
+
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -20,7 +20,7 @@ func TestGetParsedExpressionDisplay(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-func TestGetParsedExpressionDisplayInSpecifiedLocale(t *testing.T) {
+func TestGetParsedExpressionDisplay_Locale(t *testing.T) {
   cmd := getRootCommand()
   result := test.RunCmd(cmd, fmt.Sprintf("-l@ja@%s", cronExpression))
   if result.Error != nil {
@@ -30,7 +30,7 @@ func TestGetParsedExpressionDisplayInSpecifiedLocale(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-func TestGetParsedExpressionDisplayInSpecifiedLocaleLong(t *testing.T) {
+func TestGetParsedExpressionDisplay_LocaleLong(t *testing.T) {
   cmd := getRootCommand()
   result := test.RunCmd(cmd, fmt.Sprintf("--locale@ja@%s", cronExpression))
   if result.Error != nil {
@@ -40,7 +40,7 @@ func TestGetParsedExpressionDisplayInSpecifiedLocaleLong(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-func TestGetParsedExpressionDisplayIn24TimeFormat(t *testing.T) {
+func TestGetParsedExpressionDisplay_24hrsFormat(t *testing.T) {
   cmd := getRootCommand()
   result := test.RunCmd(cmd, fmt.Sprintf("--24-hour@%s", cronExpression))
   if result.Error != nil {
@@ -50,7 +50,7 @@ func TestGetParsedExpressionDisplayIn24TimeFormat(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-func TestGetParsedExpressionDisplayStartingAt1(t *testing.T) {
+func TestGetParsedExpressionDisplay_DowStartsAtOne(t *testing.T) {
   cmd := getRootCommand()
   result := test.RunCmd(cmd, fmt.Sprintf("-d@%s", cronExpression))
   if result.Error != nil {
@@ -60,7 +60,7 @@ func TestGetParsedExpressionDisplayStartingAt1(t *testing.T) {
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }
 
-func TestGetParsedExpressionDisplayStartingAt1Long(t *testing.T) {
+func TestGetParsedExpressionDisplay_DowStartsAtOneLong(t *testing.T) {
   cmd := getRootCommand()
   result := test.RunCmd(cmd, fmt.Sprintf("--dow-starts-at-one@%s", cronExpression))
   if result.Error != nil {

--- a/cmd/parser.go
+++ b/cmd/parser.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+  "fmt"
+
+  "github.com/lnquy/cron"
+)
+
+func GetExprDescriptor(loc cron.LocaleType) (exprDesc *cron.ExpressionDescriptor, err error) {
+  exprDesc, err = cron.NewDescriptor(
+    cron.Use24HourTimeFormat(format24),
+    cron.DayOfWeekStartsAtOne(dayOfWeek),
+    cron.Verbose(verbose),
+    cron.SetLocales(loc),
+  )
+
+  if err != nil {
+    return nil, fmt.Errorf("ctap: failed to initialize cron expression descriptor: %s", err)
+  }
+
+  return exprDesc, nil
+}
+
+func GetParseLocale() (loc cron.LocaleType, err error) {
+  loc, err = cron.ParseLocale(locale)
+  if err != nil {
+    return loc, fmt.Errorf("ctap: failed to get locale: %w", err)
+  }
+
+  return loc, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,16 +14,24 @@ func New() *cobra.Command {
         cmd.Print(GetVersionDisplay())
         return nil
       }
-      if len(args) < 1 {
-        cmd.Println(cmd.UsageString())
+
+      if len(args) > 0 {
+        cmd.Print(GetParsedExpressionDisplay(args))
         return nil
       }
-      cmd.Print(GetParsedExpressionDisplay(args))
+
+      if len(file) > 0 {
+        cmd.Print(GetParsedExpressionFromFileDisplay(args))
+        return nil
+      }
+
+      cmd.Println(cmd.UsageString())
       return nil
     },
   }
 
   rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
+  rootCmd.Flags().StringVarP(&file, "input", "i", "", "Path to crontab file")
   rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information")
   rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
   rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+  "fmt"
   "strings"
   "testing"
 
@@ -130,6 +131,40 @@ func TestRootCmd_LocaleLong(t *testing.T) {
   }
 
   if locale != "ja" {
+    t.Error("Expected to be true")
+  }
+}
+
+func TestRootCmd_Input(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile("")
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("-i@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  if file != fileName {
+    t.Error("Expected to be true")
+  }
+}
+
+func TestRootCmd_InputLong(t *testing.T) {
+  fileName := test.WriteTmpCrontabFile("")
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("--input@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  if file != fileName {
     t.Error("Expected to be true")
   }
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -64,8 +64,9 @@ func TestRootCmd_StringOptions(t *testing.T) {
     t.Error(result.Error)
   }
 
-  stringArgs := [1][2]string{
+  stringArgs := [2][2]string{
     {locale, "en"},
+    {file, ""},
   }
 
   if !matchString(stringArgs) {
@@ -73,7 +74,7 @@ func TestRootCmd_StringOptions(t *testing.T) {
   }
 }
 
-func matchString(arr [1][2]string) bool {
+func matchString(arr [2][2]string) bool {
   for _, setOfVal := range arr {
     if setOfVal[0] != setOfVal[1] {
       return false

--- a/test/crontab.sample
+++ b/test/crontab.sample
@@ -1,0 +1,50 @@
+#--------------------------------------------------
+# example unix/linux crontab file format:
+#--------------------------------------------------
+# min,hour,dayOfMonth,month,dayOfWeek command
+#
+# field          allowed values
+# -----          --------------
+# minute         0-59
+# hour           0-23
+# day of month   1-31
+# month          1-12 (or names, see below)
+# day of week    0-7 (0 or 7 is Sun, or use names)
+#
+#--------------------------------------------------
+
+# run the drupal cron process every hour of every day
+0 * * * * /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+
+# run this apache kludge every minute of every day
+* * * * * root /var/www/devdaily.com/bin/check-apache.sh
+
+# generate links to new blog posts twice a day
+5 10,22 * * * /var/www/devdaily.com/bin/mk-new-links.php
+
+# run the backup scripts at 4:30am
+30 4 * * * /var/www/devdaily.com/bin/create-all-backups.sh
+
+# re-generate the blog "categories" list (four times a day)
+5 0,4,10,16 * * * /var/www/devdaily.com/bin/create-cat-list.sh
+
+# reset the contact form just after midnight
+5 0 * * * /var/www/devdaily.com/bin/resetContactForm.sh
+
+# rotate the ad banners every five minutes
+
+0,20,40  * * * * /var/www/bin/ads/freshMint.sh
+5,25,45  * * * * /var/www/bin/ads/greenTaffy.sh
+10,30,50 * * * * /var/www/bin/ads/raspberry.sh
+15,35,55 * * * * /var/www/bin/ads/robinsEgg.sh
+
+# update sample data cache
+8 */1 * * * ruby $APP_ROOT/script/rails runner -e $ROR_ENV "Sample::CacheUpdate.execute"
+
+# Standalone cron expressions
+* * * * *
+* * * * * *
+* * * * * 2020
+0 * * * * *
+* * * * * * *
+0 9 * * 1-5

--- a/test/utils.go
+++ b/test/utils.go
@@ -3,10 +3,15 @@ package test
 import (
   "bytes"
   "fmt"
+  "io/ioutil"
+  "os"
   "strings"
   "testing"
+
   "github.com/spf13/cobra"
 )
+
+const tmpFileName = "crontab.sample"
 
 type resulter struct {
   Error error
@@ -34,4 +39,18 @@ func AssertResult(t *testing.T, expectedValue interface{}, actualValue interface
   if expectedValue != actualValue {
     t.Error("\nExpected: ", expectedValue, "\n     Got: ", actualValue, fmt.Sprintf("\n    Type:  %T", actualValue))
   }
+}
+
+func WriteTmpCrontabFile(content string) string {
+  tmpFile, _ := ioutil.TempFile("", tmpFileName)
+  defer func() {
+    _ = tmpFile.Close()
+  }()
+
+  _, _ = tmpFile.Write([]byte(content))
+  return tmpFile.Name()
+}
+
+func RemoveTmpCrontabFile(name string) {
+  _ = os.Remove(name)
 }


### PR DESCRIPTION
## Summary
- extract functions parsing cron expression into a new file.
- add --input, -i options, and now is able to parse from an input file