### PR TITLE
Add -o, --output options which allows to print out results to the specified file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+/tmp/*
+!/tmp/.gitkeep

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -13,7 +13,8 @@ var (
   validCronExpression = regexp.MustCompile(`^[wWlL /?,*#\-0-9]*$`)
 
   locale = "en"
-  file = ""
+  inputFile = ""
+  outputFile = ""
   version = false
   dayOfWeek = false
   verbose = false

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -29,7 +29,6 @@ func GetParsedExpressionDisplay(args []string) string {
   results := fmt.Sprintf("%s: %s\n", expr, desc)
 
   if len(outputFilePath) > 0 {
-    // TODO: extract this procedure to another function
     message := []byte(results)
 
     absolutePath, _ := filepath.Abs(outputFilePath)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -3,6 +3,7 @@ package cmd
 import (
   "fmt"
   "io/ioutil"
+  "path/filepath"
   "strings"
 )
 
@@ -30,7 +31,9 @@ func GetParsedExpressionDisplay(args []string) string {
   if len(outputFilePath) > 0 {
     // TODO: extract this procedure to another function
     message := []byte(results)
-    err := ioutil.WriteFile(outputFilePath, message, 0644)
+
+    absolutePath, _ := filepath.Abs(outputFilePath)
+    err := ioutil.WriteFile(absolutePath, message, 0644)
     if err != nil {
       return fmt.Sprintln(err.Error())
     }

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
   "fmt"
+  "io/ioutil"
+  "strings"
 )
 
 func GetParsedExpressionDisplay(args []string) string {
   expr := args[0]
+  outputFilePath := strings.TrimSpace(outputFile)
 
   loc, err := GetParseLocale()
   if err != nil {
@@ -22,5 +25,18 @@ func GetParsedExpressionDisplay(args []string) string {
     return fmt.Sprintln(err.Error())
   }
 
-  return fmt.Sprintf("%s: %s\n", expr, desc)
+  results := fmt.Sprintf("%s: %s\n", expr, desc)
+
+  if len(outputFilePath) > 0 {
+    // TODO: extract this procedure to another function
+    message := []byte(results)
+    err := ioutil.WriteFile(outputFilePath, message, 0644)
+    if err != nil {
+      return fmt.Sprintln(err.Error())
+    }
+
+    return fmt.Sprintf("ctap: the results are printed out to %s.\n", outputFilePath)
+  }
+
+  return results
 }

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -39,9 +39,10 @@ func GetParsedExpressionFromFileDisplay(args []string) string {
   }
 
   if len(outputFilePath) > 0 {
-    // TODO: extract this procedure to another function
     message := []byte(results)
-    err := ioutil.WriteFile(outputFilePath, message, 0644)
+
+    absolutePath, _ := filepath.Abs(outputFilePath)
+    err := ioutil.WriteFile(absolutePath, message, 0644)
     if err != nil {
       return fmt.Sprintln(err.Error())
     }

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -5,6 +5,7 @@ import (
   "fmt"
   "io"
   "io/ioutil"
+  "path/filepath"
   "os"
   "strings"
 

--- a/cmd/parse_file_test.go
+++ b/cmd/parse_file_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
   "fmt"
+  "io/ioutil"
   "strings"
   "testing"
 
@@ -134,4 +135,52 @@ func TestGetParsedExpressionFromFileDisplay_DowStartsAtOne(t *testing.T) {
 0 05 * * 1-5: At 05:00 AM, Sunday through Thursday | root /var/www/db-backup.sh`
 
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_Output(t *testing.T) {
+  inputFileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(inputFileName)
+
+  outputFileName := "../tmp/crontab.test.txt"
+  defer test.RemoveTmpCrontabFile(outputFileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-i@%s@-o@%s", inputFileName, outputFileName))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := fmt.Sprintf("ctap: the results are printed out to %s.", outputFileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+
+  expectedOutput = `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00 AM, Monday through Friday | root /var/www/db-backup.sh`
+
+  data, _ := ioutil.ReadFile(outputFileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(string(data), "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_OutputLong(t *testing.T) {
+  inputFileName := test.WriteTmpCrontabFile(crontabContent)
+  defer test.RemoveTmpCrontabFile(inputFileName)
+
+  outputFileName := "../tmp/crontab.test.txt"
+  defer test.RemoveTmpCrontabFile(outputFileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-i@%s@--output@%s", inputFileName, outputFileName))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  expectedOutput := fmt.Sprintf("ctap: the results are printed out to %s.", outputFileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+
+  expectedOutput = `0 * * * *: Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *: At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5: At 05:00 AM, Monday through Friday | root /var/www/db-backup.sh`
+
+  data, _ := ioutil.ReadFile(outputFileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(string(data), "\n "))
 }

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
   "fmt"
+  "io/ioutil"
   "strings"
   "testing"
 
@@ -68,4 +69,38 @@ func TestGetParsedExpressionDisplay_DowStartsAtOneLong(t *testing.T) {
   }
   expectedOutput := "0 05 * * 1-5: At 05:00 AM, Sunday through Thursday"
   test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionDisplay_Output(t *testing.T) {
+  fileName := "../tmp/crontab.test.txt"
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("-o@%s@%s", fileName, cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := fmt.Sprintf("ctap: the results are printed out to %s.", fileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+
+  expectedOutput = "0 05 * * 1-5: At 05:00 AM, Monday through Friday"
+  data, _ := ioutil.ReadFile(fileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(string(data), "\n "))
+}
+
+func TestGetParsedExpressionDisplay_OutputLong(t *testing.T) {
+  fileName := "../tmp/crontab.test.txt"
+  defer test.RemoveTmpCrontabFile(fileName)
+
+  cmd := getRootCommand()
+  result := test.RunCmd(cmd, fmt.Sprintf("--output@%s@%s", fileName, cronExpression))
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+  expectedOutput := fmt.Sprintf("ctap: the results are printed out to %s.", fileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+
+  expectedOutput = "0 05 * * 1-5: At 05:00 AM, Monday through Friday"
+  data, _ := ioutil.ReadFile(fileName)
+  test.AssertResult(t, expectedOutput, strings.Trim(string(data), "\n "))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func New() *cobra.Command {
         return nil
       }
 
-      if len(file) > 0 {
+      if len(inputFile) > 0 {
         cmd.Print(GetParsedExpressionFromFileDisplay(args))
         return nil
       }
@@ -30,12 +30,13 @@ func New() *cobra.Command {
     },
   }
 
-  rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale")
-  rootCmd.Flags().StringVarP(&file, "input", "i", "", "Path to crontab file")
-  rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information")
-  rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7)")
-  rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format")
-  rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format")
+  rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale.")
+  rootCmd.Flags().StringVarP(&inputFile, "input", "i", "", "Path to a crontab file to be read from.")
+  rootCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Path to an output file. If this option is not set, the results are printed out to standard output.")
+  rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information.")
+  rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7).")
+  rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format.")
+  rootCmd.Flags().BoolVar(&format24, "24-hour", false, "Prints description in 24 hour time format.")
 
   return rootCmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -65,9 +65,10 @@ func TestRootCmd_StringOptions(t *testing.T) {
     t.Error(result.Error)
   }
 
-  stringArgs := [2][2]string{
+  stringArgs := [3][2]string{
     {locale, "en"},
     {inputFile, ""},
+    {outputFile, ""},
   }
 
   if !matchString(stringArgs) {
@@ -75,7 +76,7 @@ func TestRootCmd_StringOptions(t *testing.T) {
   }
 }
 
-func matchString(arr [2][2]string) bool {
+func matchString(arr [3][2]string) bool {
   for _, setOfVal := range arr {
     if setOfVal[0] != setOfVal[1] {
       return false
@@ -165,6 +166,38 @@ func TestRootCmd_InputLong(t *testing.T) {
   }
 
   if inputFile != fileName {
+    t.Error("Expected to be true")
+  }
+}
+
+func TestRootCmd_Output(t *testing.T) {
+  fileName := "tmp/crontab.test.txt"
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("-o@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  if outputFile != fileName {
+    t.Error("Expected to be true")
+  }
+}
+
+func TestRootCmd_OutputLong(t *testing.T) {
+  fileName := "tmp/crontab.test.txt"
+
+  cmd := getRootCommand()
+  opts := fmt.Sprintf("--output@%s", fileName)
+
+  result := test.RunCmd(cmd, opts)
+  if result.Error != nil {
+    t.Error(result.Error)
+  }
+
+  if outputFile != fileName {
     t.Error("Expected to be true")
   }
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -67,7 +67,7 @@ func TestRootCmd_StringOptions(t *testing.T) {
 
   stringArgs := [2][2]string{
     {locale, "en"},
-    {file, ""},
+    {inputFile, ""},
   }
 
   if !matchString(stringArgs) {
@@ -147,7 +147,7 @@ func TestRootCmd_Input(t *testing.T) {
     t.Error(result.Error)
   }
 
-  if file != fileName {
+  if inputFile != fileName {
     t.Error("Expected to be true")
   }
 }
@@ -164,7 +164,7 @@ func TestRootCmd_InputLong(t *testing.T) {
     t.Error(result.Error)
   }
 
-  if file != fileName {
+  if inputFile != fileName {
     t.Error("Expected to be true")
   }
 }


### PR DESCRIPTION
## Summary
- Add -o, --output options which allows to print out results to the specified file.
- Add test cases for this function.