### PR TITLE
 Add -f, --format options which allows to print out in the specified format

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -12,9 +12,14 @@ const (
 var (
 	validCronExpression = regexp.MustCompile(`^[wWlL /?,*#\-0-9]*$`)
 
+	validFormatTypes = []string{formatCsv, formatMd}
+	formatCsv        = "csv"
+	formatMd         = "markdown"
+
 	locale     = "en"
 	inputFile  = ""
 	outputFile = ""
+	format     = ""
 	version    = false
 	dayOfWeek  = false
 	verbose    = false

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -26,16 +26,7 @@ func GetParsedExpressionDisplay(args []string) string {
 		return fmt.Sprintln(err.Error())
 	}
 
-	if contains(validFormatTypes, formatType) {
-		switch formatType {
-		case formatCsv:
-			results := fmt.Sprintf("%s, %s\n", expr, desc)
-		case formatMd:
-			results := fmt.Sprintf("| %s | %s |\n", expr, desc)
-		}
-	} else {
-		results := fmt.Sprintf("%s: %s\n", expr, desc)
-	}
+	results := fmt.Sprintf("%s: %s\n", expr, desc)
 
 	if len(outputFilePath) > 0 {
 		message := []byte(results)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -26,7 +26,16 @@ func GetParsedExpressionDisplay(args []string) string {
 		return fmt.Sprintln(err.Error())
 	}
 
-	results := fmt.Sprintf("%s: %s\n", expr, desc)
+	if contains(validFormatTypes, formatType) {
+		switch formatType {
+		case formatCsv:
+			results := fmt.Sprintf("%s, %s\n", expr, desc)
+		case formatMd:
+			results := fmt.Sprintf("| %s | %s |\n", expr, desc)
+		}
+	} else {
+		results := fmt.Sprintf("%s: %s\n", expr, desc)
+	}
 
 	if len(outputFilePath) > 0 {
 		message := []byte(results)

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 func GetParsedExpressionFromFileDisplay(args []string) string {
 	filePath := strings.TrimSpace(inputFile)
 	outputFilePath := strings.TrimSpace(outputFile)
+	formatType := strings.TrimSpace(format)
 
 	loc, err := GetParseLocale()
 	if err != nil {
@@ -42,7 +44,18 @@ func GetParsedExpressionFromFileDisplay(args []string) string {
 	if len(outputFilePath) > 0 {
 		message := []byte(results)
 
+		if contains(validFormatTypes, formatType) {
+			ext := path.Ext(outputFilePath)
+			switch formatType {
+			case formatCsv:
+				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".csv"
+			case formatMd:
+				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".md"
+			}
+		}
+
 		absolutePath, _ := filepath.Abs(outputFilePath)
+
 		err := ioutil.WriteFile(absolutePath, message, 0644)
 		if err != nil {
 			return fmt.Sprintln(err.Error())
@@ -88,7 +101,7 @@ func stream(exprDesc *cron.ExpressionDescriptor, localeType cron.LocaleType, rea
 			if contains(validFormatTypes, formatType) {
 				switch formatType {
 				case formatCsv:
-					lines = append(lines, fmt.Sprintf("%s, %s, %s\n", expr, desc, remaining))
+					lines = append(lines, fmt.Sprintf("\"%s\", \"%s\", %s\n", expr, desc, remaining))
 				case formatMd:
 					lines = append(lines, fmt.Sprintf("| %s | %s | %s |\n", expr, desc, remaining))
 				}
@@ -99,7 +112,7 @@ func stream(exprDesc *cron.ExpressionDescriptor, localeType cron.LocaleType, rea
 			if contains(validFormatTypes, formatType) {
 				switch formatType {
 				case formatCsv:
-					lines = append(lines, fmt.Sprintf("%s, %s\n", expr, desc))
+					lines = append(lines, fmt.Sprintf("\"%s\", \"%s\"\n", expr, desc))
 				case formatMd:
 					lines = append(lines, fmt.Sprintf("| %s | %s |\n", expr, desc))
 				}

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-  "path"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -44,15 +44,15 @@ func GetParsedExpressionFromFileDisplay(args []string) string {
 	if len(outputFilePath) > 0 {
 		message := []byte(results)
 
-    if contains(validFormatTypes, formatType) {
-      ext := path.Ext(outputFilePath)
-      switch formatType {
-      case formatCsv:
-        outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".csv"
-      case formatMd:
-        outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".md"
-      }
-    }
+		if contains(validFormatTypes, formatType) {
+			ext := path.Ext(outputFilePath)
+			switch formatType {
+			case formatCsv:
+				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".csv"
+			case formatMd:
+				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".md"
+			}
+		}
 
 		absolutePath, _ := filepath.Abs(outputFilePath)
 

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -15,6 +15,7 @@ import (
 func GetParsedExpressionFromFileDisplay(args []string) string {
 	filePath := strings.TrimSpace(inputFile)
 	outputFilePath := strings.TrimSpace(outputFile)
+	formatType := strings.TrimSpace(format)
 
 	loc, err := GetParseLocale()
 	if err != nil {
@@ -97,4 +98,14 @@ func normalize(line string) (expr string, remainder string) {
 	}
 
 	return line, ""
+}
+
+func contains(a []string, e string) bool {
+	for _, v := range a {
+		if e == v {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/parse_file.go
+++ b/cmd/parse_file.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+  "path"
 	"path/filepath"
 	"strings"
 
@@ -44,15 +44,15 @@ func GetParsedExpressionFromFileDisplay(args []string) string {
 	if len(outputFilePath) > 0 {
 		message := []byte(results)
 
-		if contains(validFormatTypes, formatType) {
-			ext := path.Ext(outputFilePath)
-			switch formatType {
-			case formatCsv:
-				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".csv"
-			case formatMd:
-				outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".md"
-			}
-		}
+    if contains(validFormatTypes, formatType) {
+      ext := path.Ext(outputFilePath)
+      switch formatType {
+      case formatCsv:
+        outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".csv"
+      case formatMd:
+        outputFilePath = outputFilePath[0:len(outputFilePath)-len(ext)] + ".md"
+      }
+    }
 
 		absolutePath, _ := filepath.Abs(outputFilePath)
 
@@ -74,9 +74,9 @@ func stream(exprDesc *cron.ExpressionDescriptor, localeType cron.LocaleType, rea
 	if contains(validFormatTypes, formatType) {
 		switch formatType {
 		case formatCsv:
-			lines = append(lines, fmt.Sprintf("Original, Translated, Command\n"))
+			lines = append(lines, "Original, Translated, Command\n")
 		case formatMd:
-			lines = append(lines, fmt.Sprintf("| Original | Translated | Command |\n|---|---|---|\n"))
+			lines = append(lines, "| Original | Translated | Command |\n|---|---|---|\n")
 		}
 	}
 

--- a/cmd/parse_file_test.go
+++ b/cmd/parse_file_test.go
@@ -219,9 +219,9 @@ func TestGetParsedExpressionFromFileDisplay_FormatCsv(t *testing.T) {
 		t.Error(result.Error)
 	}
 	expectedOutput := `Original, Translated, Command
-0 * * * *, Every hour, /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
-5 0 * * *, At 12:05 AM, /var/www/devdaily.com/bin/resetContactForm.sh
-0 05 * * 1-5, At 05:00 AM; Monday through Friday, root /var/www/db-backup.sh`
+"0 * * * *", "Every hour", /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+"5 0 * * *", "At 12:05 AM", /var/www/devdaily.com/bin/resetContactForm.sh
+"0 05 * * 1-5", "At 05:00 AM, Monday through Friday", root /var/www/db-backup.sh`
 
 	test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
 }

--- a/cmd/parse_file_test.go
+++ b/cmd/parse_file_test.go
@@ -184,3 +184,44 @@ func TestGetParsedExpressionFromFileDisplay_OutputLong(t *testing.T) {
 	data, _ := ioutil.ReadFile(outputFileName)
 	test.AssertResult(t, expectedOutput, strings.Trim(string(data), "\n "))
 }
+
+func TestGetParsedExpressionFromFileDisplay_FormatMarkdown(t *testing.T) {
+	formatType := "markdown"
+	fileName := test.WriteTmpCrontabFile(crontabContent)
+	defer test.RemoveTmpCrontabFile(fileName)
+
+	cmd := getRootCommand()
+	opts := fmt.Sprintf("-i@%s@-f@%s", fileName, formatType)
+
+	result := test.RunCmd(cmd, opts)
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+	expectedOutput := `| Original | Translated | Command |
+|---|---|---|
+| 0 * * * * | Every hour | /usr/bin/wget -O - -q -t 1 http://localhost/cron.php |
+| 5 0 * * * | At 12:05 AM | /var/www/devdaily.com/bin/resetContactForm.sh |
+| 0 05 * * 1-5 | At 05:00 AM, Monday through Friday | root /var/www/db-backup.sh |`
+
+	test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}
+
+func TestGetParsedExpressionFromFileDisplay_FormatCsv(t *testing.T) {
+	formatType := "csv"
+	fileName := test.WriteTmpCrontabFile(crontabContent)
+	defer test.RemoveTmpCrontabFile(fileName)
+
+	cmd := getRootCommand()
+	opts := fmt.Sprintf("-i@%s@--format@%s", fileName, formatType)
+
+	result := test.RunCmd(cmd, opts)
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+	expectedOutput := `Original, Translated, Command
+0 * * * *, Every hour, /usr/bin/wget -O - -q -t 1 http://localhost/cron.php
+5 0 * * *, At 12:05 AM, /var/www/devdaily.com/bin/resetContactForm.sh
+0 05 * * 1-5, At 05:00 AM; Monday through Friday, root /var/www/db-backup.sh`
+
+	test.AssertResult(t, expectedOutput, strings.Trim(result.Output, "\n "))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func New() *cobra.Command {
 	rootCmd.Flags().StringVarP(&locale, "locale", "l", "en", "Prints description in the specified locale.")
 	rootCmd.Flags().StringVarP(&inputFile, "input", "i", "", "Path to a crontab file to be read from.")
 	rootCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Path to an output file. If this option is not set, the results are printed out to standard output.")
+	rootCmd.Flags().StringVarP(&format, "format", "f", "", "Prints out in the specified format. options: csv, markdown")
 	rootCmd.Flags().BoolVarP(&version, "version", "V", false, "Prints version information.")
 	rootCmd.Flags().BoolVarP(&dayOfWeek, "dow-starts-at-one", "d", false, "Is day of the week starts at 1 (Monday-Sunday: 1-7).")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Prints description in verbose format.")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -65,10 +65,11 @@ func TestRootCmd_StringOptions(t *testing.T) {
 		t.Error(result.Error)
 	}
 
-	stringArgs := [3][2]string{
+	stringArgs := [4][2]string{
 		{locale, "en"},
 		{inputFile, ""},
 		{outputFile, ""},
+		{format, ""},
 	}
 
 	if !matchString(stringArgs) {
@@ -76,7 +77,7 @@ func TestRootCmd_StringOptions(t *testing.T) {
 	}
 }
 
-func matchString(arr [3][2]string) bool {
+func matchString(arr [4][2]string) bool {
 	for _, setOfVal := range arr {
 		if setOfVal[0] != setOfVal[1] {
 			return false
@@ -113,25 +114,33 @@ func TestRootCmd_HelpLong(t *testing.T) {
 }
 
 func TestRootCmd_Locale(t *testing.T) {
+	localeType := "ja"
+
 	cmd := getRootCommand()
-	result := test.RunCmd(cmd, "-l@ja")
+	opts := fmt.Sprintf("-l@%s", localeType)
+
+	result := test.RunCmd(cmd, opts)
 	if result.Error != nil {
 		t.Error(result.Error)
 	}
 
-	if locale != "ja" {
+	if locale != localeType {
 		t.Error("Expected to be true")
 	}
 }
 
 func TestRootCmd_LocaleLong(t *testing.T) {
+	localeType := "ja"
+
 	cmd := getRootCommand()
-	result := test.RunCmd(cmd, "--locale@ja")
+	opts := fmt.Sprintf("--locale@%s", localeType)
+
+	result := test.RunCmd(cmd, opts)
 	if result.Error != nil {
 		t.Error(result.Error)
 	}
 
-	if locale != "ja" {
+	if locale != localeType {
 		t.Error("Expected to be true")
 	}
 }
@@ -198,6 +207,38 @@ func TestRootCmd_OutputLong(t *testing.T) {
 	}
 
 	if outputFile != fileName {
+		t.Error("Expected to be true")
+	}
+}
+
+func TestRootCmd_Format(t *testing.T) {
+	formatType := "csv"
+
+	cmd := getRootCommand()
+	opts := fmt.Sprintf("-f@%s", formatType)
+
+	result := test.RunCmd(cmd, opts)
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+
+	if format != formatType {
+		t.Error("Expected to be true")
+	}
+}
+
+func TestRootCmd_FormatLong(t *testing.T) {
+	formatType := "csv"
+
+	cmd := getRootCommand()
+	opts := fmt.Sprintf("--format@%s", formatType)
+
+	result := test.RunCmd(cmd, opts)
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+
+	if format != formatType {
 		t.Error("Expected to be true")
 	}
 }


### PR DESCRIPTION
## Summary
- Add -f, --format options which allows to print out in the specified format(csv, markdown)
- Add test cases which cover new features
